### PR TITLE
[OD-XXX] Update Plugin.py

### DIFF
--- a/ckanext/agsview/plugin.py
+++ b/ckanext/agsview/plugin.py
@@ -23,7 +23,7 @@ def ags_view_default_basemap_url():
 
 
 def ags_view_proxy():
-    return config.get('ckanext.ags_view_proxy', '')
+    return config.get('ckanext.ags_view_proxy', {})
 
 
 def with_proxy(url):


### PR DESCRIPTION
The default value of ags_view_proxy function is set to an empty string, which throws Value Error: No JSON object could be decoded if ckanext.ags_view_procy is not set in the ini file